### PR TITLE
Add support for local SSL file paths for PuppetDB queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ class { 'patching_status':
 }
 ```
 
+Alternatively, for Puppet Enterprise or similar setup where a client certificate can be used to connect to PuppetDB:
+```puppet
+class { 'patching_status':
+  web_base      => /webserver/directory,
+  script_base   => /script/path,
+  puppetdb      => '192.168.1.10',
+  ssl_enabled   => true,
+  ssl_cert_file => '/etc/puppetlabs/puppet/ssl/certs/certname.pem'
+  ca_cert_file  => '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+  ssl_key_file  => '/etc/puppetlabs/puppet/ssl/private_keys/certname.pem'
+}
+```
+In Puppet Enterprise, you will also need to add the host this class is running on to the whitelist at puppet_enterprise::profile::puppetdb::whitelisted_certnames.
+
 ## Screenshot
 
 ![Screenshot N/A](https://wiki.geant.org/download/attachments/126981072/patching_status.png  "Patching Status")

--- a/templates/patching_status.conf.epp
+++ b/templates/patching_status.conf.epp
@@ -2,9 +2,9 @@
 
 <% if $ssl_enabled { -%>
 ssl_enabled = True
-ssl_cert = <%= $script_base %>/puppetdb_certs/cert.crt
-ssl_key = <%= $script_base %>/puppetdb_certs/cert.key
-ca_cert = <%= $script_base %>/puppetdb_certs/ca_cert.crt
+ssl_cert = <%= $ssl_cert_file %>
+ssl_key = <%= $ssl_key_file %>
+ca_cert = <%= $ca_cert_file %>
 <% } else { -%>
 ssl_enabled =
 <% } -%>


### PR DESCRIPTION
Add parameters to accept file-system paths for certificates used when communicating with PuppetDB.  Integrated them so that either method for providing certificate content can be used.